### PR TITLE
Add asm constraints for gdc

### DIFF
--- a/source/keepalive.d
+++ b/source/keepalive.d
@@ -34,7 +34,8 @@ auto keepAlive(T)(T val) if (is(T == U*, U) || is(T == class) || is(T == interfa
         @disable this(this);
 
         @nogc nothrow @safe pure ~this() {
-            asm @nogc nothrow @safe pure {}
+            version (GNU) asm @nogc nothrow @safe pure { "" :: "rm" (this._val); }
+            else asm @nogc nothrow @safe pure {}
         }
     }
     return KeepAlive(val);


### PR DESCRIPTION
Otherwise it optimises everything out.

(Only visible w/pragma(inline), which can't be added because dmd/ldc don't like it and gdc isn't new enough to accept non-literals, buuut.)